### PR TITLE
Switch to approximate-number

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,10 +38,9 @@
   },
   "dependencies": {
     "@nutmeg/seed": "0.9.0",
-    "numeral": "2.0.6"
+    "approximate-number": "2.0.0"
   },
   "devDependencies": {
-    "@nutmeg/cli": "0.11.2",
-    "@types/numeral": "0.0.22"
+    "@nutmeg/cli": "0.11.2"
   }
 }

--- a/src/github-repository.ts
+++ b/src/github-repository.ts
@@ -1,5 +1,5 @@
 import { Seed, Property, html, svg, TemplateResult } from '@nutmeg/seed';
-import * as numeral from 'numeral';
+import approximateNumber from 'approximate-number';
 
 import { Cache } from './cache';
 import { Repo, RepoData } from './repo';
@@ -65,13 +65,7 @@ export class GithubRepository extends Seed {
   }
 
   private countDisplay(count: number): string {
-    if (count < 1000) {
-      return String(count);
-    } else if (count < 100000) {
-      return numeral(count).format('0a');
-    } else {
-      return numeral(count).format('0.00a');
-    }
+    return approximateNumber(count);
   }
 
   /** Styling for the component. */

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,0 +1,4 @@
+declare module 'approximate-number' {
+  function approximateNumber(num: number, opts?: {}): string;
+  export default approximateNumber;
+}


### PR DESCRIPTION
Gzip size of github-repository.min.js:
- before: 17.73 KB
- after: 14.16 KB